### PR TITLE
Add event for loading config form

### DIFF
--- a/Controller/ConfigController.php
+++ b/Controller/ConfigController.php
@@ -13,6 +13,7 @@ namespace MauticPlugin\IntegrationsBundle\Controller;
 
 use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\PluginBundle\Entity\Integration;
+use MauticPlugin\IntegrationsBundle\Event\FormLoadEvent;
 use MauticPlugin\IntegrationsBundle\Exception\IntegrationNotFoundException;
 use MauticPlugin\IntegrationsBundle\Exception\RequiredFieldsMissingException;
 use MauticPlugin\IntegrationsBundle\Form\Type\IntegrationConfigType;
@@ -22,6 +23,7 @@ use MauticPlugin\IntegrationsBundle\Integration\BasicIntegration;
 use MauticPlugin\IntegrationsBundle\Integration\Interfaces\ConfigFormFeaturesInterface;
 use MauticPlugin\IntegrationsBundle\Integration\Interfaces\ConfigFormInterface;
 use MauticPlugin\IntegrationsBundle\Integration\Interfaces\ConfigFormSyncInterface;
+use MauticPlugin\IntegrationsBundle\SyncEvents;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -79,6 +81,10 @@ class ConfigController extends AbstractFormController
         } catch (IntegrationNotFoundException $exception) {
             return $this->notFound();
         }
+
+        $dispatcher = $this->get('event_dispatcher');
+        $event      = new FormLoadEvent($this->integrationConfiguration);
+        $dispatcher->dispatch(SyncEvents::INTEGRATION_CONFIG_FORM_LOAD, $event);
 
         // Set the request for private methods
         $this->request = $request;

--- a/Event/FormLoadEvent.php
+++ b/Event/FormLoadEvent.php
@@ -21,23 +21,23 @@ class FormLoadEvent extends Event
     /**
      * @var Integration
      */
-    private $integration;
+    private $integrationConfiguration;
 
     public function __construct(Integration $integration)
     {
-        $this->integration = $integration;
+        $this->integrationConfiguration = $integration;
     }
 
     /**
      * @return Integration
      */
-    public function getIntegration(): Integration
+    public function getIntegrationConfiguration(): Integration
     {
-        return $this->integration;
+        return $this->integrationConfiguration;
     }
 
-    public function getIntegrationName()
+    public function getIntegration()
     {
-        return $this->integration->getName();
+        return $this->integrationConfiguration->getName();
     }
 }

--- a/Event/FormLoadEvent.php
+++ b/Event/FormLoadEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\IntegrationsBundle\Event;
+
+use Mautic\PluginBundle\Entity\Integration;
+use Symfony\Component\EventDispatcher\Event;
+
+class FormLoadEvent extends Event
+{
+    /**
+     * @var Integration
+     */
+    private $integration;
+
+    public function __construct(Integration $integration)
+    {
+        $this->integration = $integration;
+    }
+
+    /**
+     * @return Integration
+     */
+    public function getIntegration(): Integration
+    {
+        return $this->integration;
+    }
+
+    public function getIntegrationName()
+    {
+        return $this->integration->getName();
+    }
+}

--- a/SyncEvents.php
+++ b/SyncEvents.php
@@ -4,5 +4,15 @@ namespace MauticPlugin\IntegrationsBundle;
 
 final class SyncEvents
 {
-    const INTEGRATION_POST_EXECUTE = 'mautic.sync_post_execute_integration';
+    public const INTEGRATION_POST_EXECUTE = 'mautic.sync_post_execute_integration';
+
+    /**
+     * The mautic.integration.config_form_loaded event is dispatched when config page for integration is loaded.
+     *
+     * The event listener receives a
+     * Mautic\IntegrationsBundle\Event\FormLoadEvent instance.
+     *
+     * @var string
+     */
+    public const INTEGRATION_CONFIG_FORM_LOAD = 'mautic.integration.config_form_loaded';
 }


### PR DESCRIPTION
Add an event for loading config form, so other plugins can hook on it. Plugin can clear cache for mapped field for example.