### PR TITLE
Inject integrations into lead integrations tab

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -65,6 +65,12 @@ return [
                     'controller_resolver',
                 ],
             ],
+            'mautic.integrations.subscriber.ui_contact_integrations_tab' => [
+                'class' => \MauticPlugin\IntegrationsBundle\EventListener\UIContactIntegrationsTabSubscriber::class,
+                'arguments' => [
+                    'mautic.integrations.repository.object_mapping',
+                ],
+            ],
         ],
         'forms' => [
             'mautic.integrations.form.config.integration' => [

--- a/Entity/ObjectMappingRepository.php
+++ b/Entity/ObjectMappingRepository.php
@@ -132,4 +132,26 @@ class ObjectMappingRepository  extends CommonRepository
             ->setParameter('objectName', $objectName)
             ->setParameter('objectId', $objectId);
     }
+
+    /**
+     * @param string $internalObject
+     * @param int    $internalObjectId
+     *
+     * @return ObjectMapping[]
+     */
+    public function getIntegrationMappingsForInternalObject(string $internalObject, int $internalObjectId)
+    {
+        $qb = $this->createQueryBuilder('m');
+        $qb->select('m')
+            ->where(
+                $qb->expr()->andX(
+                    $qb->expr()->eq('m.internalObjectName', ':internalObject'),
+                    $qb->expr()->eq('m.internalObjectId', ':internalObjectId')
+                )
+            )
+            ->setParameter('internalObject', $internalObject)
+            ->setParameter('internalObjectId', $internalObjectId);
+
+        return $qb->getQuery()->getResult();
+    }
 }

--- a/EventListener/UIContactIntegrationsTabSubscriber.php
+++ b/EventListener/UIContactIntegrationsTabSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\IntegrationsBundle\EventListener;
+
+
+use Mautic\CoreBundle\CoreEvents;
+use Mautic\CoreBundle\Event\CustomTemplateEvent;
+use Mautic\LeadBundle\Entity\Lead;
+use MauticPlugin\IntegrationsBundle\Entity\ObjectMappingRepository;
+use MauticPlugin\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class UIContactIntegrationsTabSubscriber
+ */
+class UIContactIntegrationsTabSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var ObjectMappingRepository
+     */
+    private $objectMappingRepository;
+
+    /**
+     * UIContactIntegrationsTabSubscriber constructor.
+     *
+     * @param ObjectMappingRepository $objectMappingRepository
+     */
+    public function __construct(ObjectMappingRepository $objectMappingRepository)
+    {
+        $this->objectMappingRepository = $objectMappingRepository;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE => ['onTemplateRender', 0],
+        ];
+    }
+
+    /**
+     * @param CustomTemplateEvent $event
+     */
+    public function onTemplateRender(CustomTemplateEvent $event)
+    {
+        if ($event->getTemplate() === 'MauticLeadBundle:Lead:lead.html.php') {
+            $vars         = $event->getVars();
+            $integrations = $vars['integrations'];
+
+            /** @var Lead $contact */
+            $contact = $vars['lead'];
+
+            $objectMappings = $this->objectMappingRepository->getIntegrationMappingsForInternalObject(
+                MauticSyncDataExchange::OBJECT_CONTACT,
+                $contact->getId()
+            );
+
+            foreach ($objectMappings as $objectMapping) {
+                $integrations[] = [
+                    'integration'           => $objectMapping->getIntegration(),
+                    'integration_entity'    => $objectMapping->getIntegrationObjectName(),
+                    'integration_entity_id' => $objectMapping->getIntegrationObjectId(),
+                    'date_added'            => $objectMapping->getDateCreated(),
+                    'last_sync_date'        => $objectMapping->getLastSyncDate()
+                ];
+            }
+
+            $vars['integrations'] = $integrations;
+
+            $event->setVars($vars);
+        }
+    }
+}


### PR DESCRIPTION
The Integrations tab on the a contact's profile page would not include mappings from the new sync engine. This appends them to that UI. 

https://github.com/mautic-inc/mautic-internal/issues/1044

Sync a contact then look at their Integrations tab on their details page. Notice  Magento or vTiger is missing. After this PR, they'll show. 

It'll need https://github.com/mautic-inc/mautic-cloud/pull/216 to show the date correctly