### PR TITLE
Fix type error

### DIFF
--- a/EventListener/LeadSubscriber.php
+++ b/EventListener/LeadSubscriber.php
@@ -123,7 +123,7 @@ class LeadSubscriber extends CommonSubscriber
      */
     public function onLeadPostDelete(Events\LeadEvent $event): void
     {
-        $this->fieldChangeRepo->deleteEntitiesForObject($event->getLead()->deletedId, Lead::class);
+        $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getLead()->deletedId, Lead::class);
     }
 
     /**


### PR DESCRIPTION
While deleting contacts in batch i got type error when delete id is string.