### PR TITLE
Refactored mapped fields - use object instead of array

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -87,9 +87,6 @@ return [
             ],
             'mautic.integrations.form.config.sync_settings_field_mappings' => [
                 'class' => \MauticPlugin\IntegrationsBundle\Form\Type\IntegrationSyncSettingsFieldMappingsType::class,
-                'arguments' => [
-                    'mautic.integrations.sync.data_exchange.mautic.field_helper',
-                ],
             ],
             'mautic.integrations.form.config.sync_settings_object_field_directions' => [
                 'class' => \MauticPlugin\IntegrationsBundle\Form\Type\IntegrationSyncSettingsObjectFieldType::class,
@@ -98,6 +95,7 @@ return [
                 'class' => \MauticPlugin\IntegrationsBundle\Form\Type\IntegrationSyncSettingsObjectFieldMappingType::class,
                 'arguments' => [
                     'translator',
+                    'mautic.integrations.sync.data_exchange.mautic.field_helper',
                 ]
             ],
             'mautic.integrations.form.config.sync_settings_object_field' => [

--- a/Controller/FieldPaginationController.php
+++ b/Controller/FieldPaginationController.php
@@ -52,8 +52,6 @@ class FieldPaginationController extends CommonController
             return $this->notFound();
         }
 
-        $fieldModel = $this->get('mautic.lead.model.field');
-
         $keyword         = $request->get('keyword');
         $featureSettings = $integrationConfiguration->getFeatureSettings();
         $currentFields   = $this->getFields($featureSettings, $integration, $object);
@@ -66,12 +64,11 @@ class FieldPaginationController extends CommonController
             $currentFields,
             [
                 'integrationFields' => $this->getFilteredFields(),
-                'mauticFields'      => $fieldModel->getFieldList(false),
                 'page'              => $page,
                 'keyword'           => $keyword,
                 'totalFieldCount'   => $this->getTotalFieldCount(),
                 'object'            => $object,
-                'integration'       => $integration,
+                'integrationObject' => $integrationObject,
                 'csrf_protection'   => false,
             ]
         );

--- a/Controller/FieldPaginationController.php
+++ b/Controller/FieldPaginationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -10,7 +12,6 @@
  */
 
 namespace MauticPlugin\IntegrationsBundle\Controller;
-
 
 use Mautic\CoreBundle\Controller\CommonController;
 use MauticPlugin\IntegrationsBundle\Exception\IntegrationNotFoundException;
@@ -64,15 +65,14 @@ class FieldPaginationController extends CommonController
             IntegrationSyncSettingsObjectFieldMappingType::class,
             $currentFields,
             [
-                'requiredIntegrationFields' => $this->getRequiredFields(),
-                'integrationFields'         => $this->getFilteredFields(),
-                'mauticFields'              => $fieldModel->getFieldList(false),
-                'page'                      => $page,
-                'keyword'                   => $keyword,
-                'totalFieldCount'           => $this->getTotalFieldCount(),
-                'object'                    => $object,
-                'integration'               => $integration,
-                'csrf_protection'           => false,
+                'integrationFields' => $this->getFilteredFields(),
+                'mauticFields'      => $fieldModel->getFieldList(false),
+                'page'              => $page,
+                'keyword'           => $keyword,
+                'totalFieldCount'   => $this->getTotalFieldCount(),
+                'object'            => $object,
+                'integration'       => $integration,
+                'csrf_protection'   => false,
             ]
         );
 

--- a/Form/Type/FilteredFieldsTrait.php
+++ b/Form/Type/FilteredFieldsTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -12,21 +14,17 @@
 namespace MauticPlugin\IntegrationsBundle\Form\Type;
 
 use MauticPlugin\IntegrationsBundle\Integration\Interfaces\ConfigFormSyncInterface;
+use MauticPlugin\IntegrationsBundle\Mapping\MappedFieldInfoInterface;
 
 trait FilteredFieldsTrait
 {
-    /**
-     * @var array
-     */
-    private $requiredFields = [];
-
     /**
      * @var int
      */
     private $totalFieldCount = 0;
 
     /**
-     * @var array
+     * @var array|MappedFieldInfoInterface[]
      */
     private $filteredFields = [];
 
@@ -36,15 +34,15 @@ trait FilteredFieldsTrait
      * @param string|null             $keyword
      * @param int                     $page
      */
-    private function filterFields(ConfigFormSyncInterface $integrationObject, string $objectName, string $keyword = null, int $page = 1)
+    private function filterFields(ConfigFormSyncInterface $integrationObject, string $objectName, string $keyword = null, int $page = 1): void
     {
-        $this->requiredFields = $integrationObject->getRequiredFieldsForMapping($objectName);
-        asort($this->requiredFields);
+        $requiredFields = $integrationObject->getRequiredFieldsForMapping($objectName);
+        asort($requiredFields);
 
         $optionalFields = $integrationObject->getOptionalFieldsForMapping($objectName);
         asort($optionalFields);
 
-        $allFields = array_merge($this->requiredFields, $optionalFields);
+        $allFields = array_merge($requiredFields, $optionalFields);
 
         if ($keyword) {
             $this->filteredFields = $this->getFieldsByKeyword($allFields, $keyword);
@@ -63,9 +61,9 @@ trait FilteredFieldsTrait
      * @param int   $page
      * @param int   $limit
      *
-     * @return array
+     * @return array|MappedFieldInfoInterface[]
      */
-    private function getPageOfFields(array $fields, int $page, int $limit = 15)
+    private function getPageOfFields(array $fields, int $page, int $limit = 15): array
     {
         $offset = ($page - 1) * $limit;
 
@@ -73,46 +71,38 @@ trait FilteredFieldsTrait
     }
 
     /**
-     * @param array  $fields
-     * @param string $keyword
+     * @param array|MappedFieldInfoInterface[] $fields
+     * @param string                           $keyword
      *
-     * @return array
+     * @return array|MappedFieldInfoInterface[]
      */
-    private function getFieldsByKeyword(array $fields, string $keyword)
+    private function getFieldsByKeyword(array $fields, string $keyword): array
     {
         $found = [];
 
-        foreach ($fields as $name => $label) {
-            if (!stristr($label, $keyword)) {
+        foreach ($fields as $name => $field) {
+            if (!stristr($field->getName(), $keyword)) {
                 continue;
             }
 
-            $found[$name] = $label;
+            $found[$name] = $field;
         }
 
         return $found;
     }
 
     /**
-     * @return mixed
+     * @return int
      */
-    private function getRequiredFields()
-    {
-        return $this->requiredFields;
-    }
-
-    /**
-     * @return mixed
-     */
-    private function getTotalFieldCount()
+    private function getTotalFieldCount(): int
     {
         return $this->totalFieldCount;
     }
 
     /**
-     * @return mixed
+     * @return array|MappedFieldInfoInterface[]
      */
-    private function getFilteredFields()
+    private function getFilteredFields(): array
     {
         return $this->filteredFields;
     }

--- a/Form/Type/FilteredFieldsTrait.php
+++ b/Form/Type/FilteredFieldsTrait.php
@@ -36,13 +36,7 @@ trait FilteredFieldsTrait
      */
     private function filterFields(ConfigFormSyncInterface $integrationObject, string $objectName, string $keyword = null, int $page = 1): void
     {
-        $requiredFields = $integrationObject->getRequiredFieldsForMapping($objectName);
-        asort($requiredFields);
-
-        $optionalFields = $integrationObject->getOptionalFieldsForMapping($objectName);
-        asort($optionalFields);
-
-        $allFields = array_merge($requiredFields, $optionalFields);
+        $allFields = $integrationObject->getAllFieldsForMapping($objectName);
 
         if ($keyword) {
             $this->filteredFields = $this->getFieldsByKeyword($allFields, $keyword);

--- a/Form/Type/IntegrationSyncSettingsFieldMappingsType.php
+++ b/Form/Type/IntegrationSyncSettingsFieldMappingsType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic, Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -47,7 +49,7 @@ class IntegrationSyncSettingsFieldMappingsType extends AbstractType
      *
      * @throws InvalidFormOptionException
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!is_array($options['objects'])) {
             throw new InvalidFormOptionException('objects must be an array');
@@ -72,20 +74,18 @@ class IntegrationSyncSettingsFieldMappingsType extends AbstractType
                     $objectName,
                     IntegrationSyncSettingsObjectFieldMappingType::class,
                     [
-                        'label'                     => false,
-                        'requiredIntegrationFields' => $this->getRequiredFields(),
-                        'integrationFields'         => $this->getFilteredFields(),
-                        'mauticFields'              => $this->getMauticFields($integrationObject, $objectName),
-                        'page'                      => 1,
-                        'keyword'                   => null,
-                        'totalFieldCount'           => $this->getTotalFieldCount(),
-                        'object'                    => $objectName,
-                        'integration'               => $integrationObject->getName(),
-                        'error_bubbling'            => false,
-                        'allow_extra_fields'        => true,
+                        'label'              => false,
+                        'integrationFields'  => $this->getFilteredFields(),
+                        'mauticFields'       => $this->getMauticFields($integrationObject, $objectName),
+                        'page'               => 1,
+                        'keyword'            => null,
+                        'totalFieldCount'    => $this->getTotalFieldCount(),
+                        'object'             => $objectName,
+                        'integration'        => $integrationObject->getName(),
+                        'error_bubbling'     => false,
+                        'allow_extra_fields' => true,
                     ]
                 );
-
 
                 if ($error) {
                     $form[$objectName]->addError(new FormError($error));
@@ -97,7 +97,7 @@ class IntegrationSyncSettingsFieldMappingsType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired(
             [
@@ -114,7 +114,7 @@ class IntegrationSyncSettingsFieldMappingsType extends AbstractType
      * @return array
      * @throws ObjectNotFoundException
      */
-    private function getMauticFields(ConfigFormSyncInterface $integrationObject, string $objectName)
+    private function getMauticFields(ConfigFormSyncInterface $integrationObject, string $objectName): array
     {
         $mappedObjects = $integrationObject->getSyncMappedObjects();
         if (!isset($mappedObjects[$objectName])) {

--- a/Form/Type/IntegrationSyncSettingsObjectFieldMappingType.php
+++ b/Form/Type/IntegrationSyncSettingsObjectFieldMappingType.php
@@ -60,7 +60,7 @@ class IntegrationSyncSettingsObjectFieldMappingType extends AbstractType
                 [
                     'label'        => $fieldInfo->getLabel(),
                     'mauticFields' => $options['mauticFields'],
-                    'required'     => $fieldInfo->isRequired(),
+                    'required'     => $fieldInfo->showAsRequired(),
                     'placeholder'  => $this->translator->trans('mautic.integration.sync_mautic_field'),
                     'object'       => $options['object'],
                     'integration'  => $options['integration'],

--- a/Form/Type/IntegrationSyncSettingsObjectFieldMappingType.php
+++ b/Form/Type/IntegrationSyncSettingsObjectFieldMappingType.php
@@ -54,18 +54,27 @@ class IntegrationSyncSettingsObjectFieldMappingType extends AbstractType
                 throw new InvalidFormOptionException('integrationFields must contain an instance of MappedFieldInfoInterface');
             }
 
+            $attr = [
+                'label'        => $fieldInfo->getLabel(),
+                'mauticFields' => $options['mauticFields'],
+                'required'     => $fieldInfo->showAsRequired(),
+                'placeholder'  => $this->translator->trans('mautic.integration.sync_mautic_field'),
+                'object'       => $options['object'],
+                'integration'  => $options['integration'],
+                'field'        => $fieldInfo,
+            ];
+
+            if ($fieldInfo->hasTooltip()) {
+                $attr['attr'] = [
+                    'tooltip' => $fieldInfo->getTooltip(),
+                    'class'   => 'form-control',
+                ];
+            }
+
             $builder->add(
                 $fieldName,
                 IntegrationSyncSettingsObjectFieldType::class,
-                [
-                    'label'        => $fieldInfo->getLabel(),
-                    'mauticFields' => $options['mauticFields'],
-                    'required'     => $fieldInfo->showAsRequired(),
-                    'placeholder'  => $this->translator->trans('mautic.integration.sync_mautic_field'),
-                    'object'       => $options['object'],
-                    'integration'  => $options['integration'],
-                    'field'        => $fieldInfo,
-                ]
+                $attr
             );
         }
 

--- a/Form/Type/IntegrationSyncSettingsObjectFieldMappingType.php
+++ b/Form/Type/IntegrationSyncSettingsObjectFieldMappingType.php
@@ -60,7 +60,7 @@ class IntegrationSyncSettingsObjectFieldMappingType extends AbstractType
                 [
                     'label'        => $fieldInfo->getLabel(),
                     'mauticFields' => $options['mauticFields'],
-                    'required'     => $fieldInfo->isMandatory(),
+                    'required'     => $fieldInfo->isRequired(),
                     'placeholder'  => $this->translator->trans('mautic.integration.sync_mautic_field'),
                     'object'       => $options['object'],
                     'integration'  => $options['integration'],

--- a/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -42,7 +42,7 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
             [
                 'label'          => false,
                 'choices'        => $options['mauticFields'],
-                'required'       => $field->isRequired(),
+                'required'       => $field->showAsRequired(),
                 'empty_value'    => '',
                 'error_bubbling' => false,
                 'attr'           => [

--- a/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -42,7 +42,7 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
             [
                 'label'          => false,
                 'choices'        => $options['mauticFields'],
-                'required'       => $field->isMandatory(),
+                'required'       => $field->isRequired(),
                 'empty_value'    => '',
                 'error_bubbling' => false,
                 'attr'           => [

--- a/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -55,15 +55,26 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
             ]
         );
 
+        $choices = [];
+        if ($field->isBidirectionalSyncEnabled()) {
+            $choices[ObjectMappingDAO::SYNC_BIDIRECTIONALLY] = 'mautic.integration.sync_direction_bidirectional';
+        }
+        if ($field->isToIntegrationSyncEnabled()) {
+            $choices[ObjectMappingDAO::SYNC_TO_INTEGRATION] = 'mautic.integration.sync_direction_integration';
+        }
+        if ($field->isToMauticSyncEnabled()) {
+            $choices[ObjectMappingDAO::SYNC_TO_MAUTIC] = 'mautic.integration.sync_direction_mautic';
+        }
+
+        if (empty($choices)) {
+            throw new InvalidFormOptionException('field "'.$field->getName().'" must allow at least 1 direction for sync');
+        }
+
         $builder->add(
             'syncDirection',
             ChoiceType::class,
             [
-                'choices'    => [
-                    ObjectMappingDAO::SYNC_BIDIRECTIONALLY => 'mautic.integration.sync_direction_bidirectional',
-                    ObjectMappingDAO::SYNC_TO_INTEGRATION  => 'mautic.integration.sync_direction_integration',
-                    ObjectMappingDAO::SYNC_TO_MAUTIC       => 'mautic.integration.sync_direction_mautic',
-                ],
+                'choices'    => $choices,
                 'label'      => false,
                 'empty_data' => ObjectMappingDAO::SYNC_BIDIRECTIONALLY,
                 'attr'       => [

--- a/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic, Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -11,6 +13,8 @@
 
 namespace MauticPlugin\IntegrationsBundle\Form\Type;
 
+use MauticPlugin\IntegrationsBundle\Exception\InvalidFormOptionException;
+use MauticPlugin\IntegrationsBundle\Mapping\MappedFieldInfoInterface;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -19,15 +23,26 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class IntegrationSyncSettingsObjectFieldType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     *
+     * @throws InvalidFormOptionException
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $field = $options['field'];
+        if (!$field instanceof MappedFieldInfoInterface) {
+            throw new InvalidFormOptionException('field must contain an instance of MappedFieldInfoInterface');
+        }
+
         $builder->add(
             'mappedField',
             ChoiceType::class,
             [
                 'label'          => false,
                 'choices'        => $options['mauticFields'],
-                'required'       => !empty($options['required']),
+                'required'       => $field->isMandatory(),
                 'empty_value'    => '',
                 'error_bubbling' => false,
                 'attr'           => [
@@ -35,7 +50,7 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
                     'data-placeholder' => $options['placeholder'],
                     'data-object'      => $options['object'],
                     'data-integration' => $options['integration'],
-                    'data-field'       => $options['field'],
+                    'data-field'       => $field->getName(),
                 ],
             ]
         );
@@ -55,7 +70,7 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
                     'class'            => 'integration-sync-direction',
                     'data-object'      => $options['object'],
                     'data-integration' => $options['integration'],
-                    'data-field'       => $options['field'],
+                    'data-field'       => $field->getName(),
                 ],
             ]
         );
@@ -64,7 +79,7 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired(
             [

--- a/Helper/FieldMergerHelper.php
+++ b/Helper/FieldMergerHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -42,11 +44,9 @@ class FieldMergerHelper
      * @param string $object
      * @param array  $updatedFieldMappings
      */
-    public function mergeSyncFieldMapping(string $object, array $updatedFieldMappings)
+    public function mergeSyncFieldMapping(string $object, array $updatedFieldMappings): void
     {
-        $requiredFields = $this->integrationObject->getRequiredFieldsForMapping($object);
-
-        $this->removeNonExistentFieldMappings($object, $requiredFields);
+        $this->removeNonExistentFieldMappings($object);
 
         $this->bindUpdatedFieldMappings($object, $updatedFieldMappings);
     }
@@ -54,19 +54,17 @@ class FieldMergerHelper
     /**
      * @return array
      */
-    public function getFieldMappings()
+    public function getFieldMappings(): array
     {
         return $this->currentFieldMappings;
     }
 
     /**
      * @param string $object
-     * @param array  $requiredFields
      */
-    private function removeNonExistentFieldMappings(string $object, array $requiredFields)
+    private function removeNonExistentFieldMappings(string $object): void
     {
-        $optionalFields = $this->integrationObject->getOptionalFieldsForMapping($object);
-        $allFields      = array_merge($requiredFields, $optionalFields);
+        $allFields = $this->integrationObject->getAllFieldsForMapping($object);
 
         if (!isset($this->currentFieldMappings[$object])) {
             $this->currentFieldMappings[$object] = [];
@@ -80,7 +78,7 @@ class FieldMergerHelper
      * @param string $object
      * @param array  $updatedFieldMappings
      */
-    private function bindUpdatedFieldMappings(string $object, array $updatedFieldMappings)
+    private function bindUpdatedFieldMappings(string $object, array $updatedFieldMappings): void
     {
         // Merge updated fields into current fields
         foreach ($updatedFieldMappings as $fieldName => $fieldMapping) {

--- a/Helper/FieldValidationHelper.php
+++ b/Helper/FieldValidationHelper.php
@@ -144,7 +144,7 @@ class FieldValidationHelper
         $requiredFields = $this->integrationObject->getRequiredFieldsForMapping($object);
 
         $missingFields = [];
-        foreach ($requiredFields as $field => $fieldObjest) {
+        foreach ($requiredFields as $field => $fieldObject) {
             if (empty($mappedFields[$field]['mappedField'])) {
                 $missingFields[] = $field;
             }

--- a/Helper/FieldValidationHelper.php
+++ b/Helper/FieldValidationHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -10,7 +12,6 @@
  */
 
 namespace MauticPlugin\IntegrationsBundle\Helper;
-
 
 use MauticPlugin\IntegrationsBundle\Integration\Interfaces\BasicInterface;
 use MauticPlugin\IntegrationsBundle\Integration\Interfaces\ConfigFormFeaturesInterface;
@@ -60,7 +61,7 @@ class FieldValidationHelper
      * @param ConfigFormSyncInterface $integrationObject
      * @param array                   $fieldMappings
      */
-    public function validateRequiredFields(Form $form, ConfigFormSyncInterface $integrationObject, array $fieldMappings)
+    public function validateRequiredFields(Form $form, ConfigFormSyncInterface $integrationObject, array $fieldMappings): void
     {
         $integrationConfiguration = $integrationObject->getIntegrationConfiguration();
         if (!$integrationConfiguration->getIsPublished()) {
@@ -79,7 +80,7 @@ class FieldValidationHelper
 
         $settings = $integrationConfiguration->getFeatureSettings();
         foreach ($settings['sync']['objects'] as $object) {
-            $objectFieldMappings = (isset($fieldMappings[$object])) ? $fieldMappings[$object] : [];
+            $objectFieldMappings = $fieldMappings[$object] ?? [];
             $fieldMappingForm    = $form['featureSettings']['sync']['fieldMappings'][$object];
 
             try {
@@ -97,7 +98,7 @@ class FieldValidationHelper
      * @param Form  $fieldMappingsForm
      * @param array $missingFields
      */
-    private function validateIntegrationRequiredFields(Form $fieldMappingsForm, array $missingFields)
+    private function validateIntegrationRequiredFields(Form $fieldMappingsForm, array $missingFields): void
     {
         $hasMissingFields  = false;
         $errorsOnGivenPage = false;
@@ -138,12 +139,12 @@ class FieldValidationHelper
      *
      * @return array
      */
-    private function findMissingIntegrationRequiredFieldMappings(string $object, array $mappedFields)
+    private function findMissingIntegrationRequiredFieldMappings(string $object, array $mappedFields): array
     {
         $requiredFields = $this->integrationObject->getRequiredFieldsForMapping($object);
 
         $missingFields = [];
-        foreach ($requiredFields as $field => $label) {
+        foreach ($requiredFields as $field => $fieldObjest) {
             if (empty($mappedFields[$field]['mappedField'])) {
                 $missingFields[] = $field;
             }
@@ -159,7 +160,7 @@ class FieldValidationHelper
      *
      * @throws ObjectNotFoundException
      */
-    private function validateMauticRequiredFields(Form $fieldMappingsForm, string $object, array $objectFieldMappings)
+    private function validateMauticRequiredFields(Form $fieldMappingsForm, string $object, array $objectFieldMappings): void
     {
         $missingFields = $this->findMissingInternalRequiredFieldMappings($object, $objectFieldMappings);
         if (empty($missingFields)) {
@@ -186,7 +187,7 @@ class FieldValidationHelper
      * @return array
      * @throws ObjectNotFoundException
      */
-    private function findMissingInternalRequiredFieldMappings(string $object, array $objectFieldMappings)
+    private function findMissingInternalRequiredFieldMappings(string $object, array $objectFieldMappings): array
     {
         $mappedObjects = $this->integrationObject->getSyncMappedObjects();
 

--- a/Integration/Interfaces/ConfigFormSyncInterface.php
+++ b/Integration/Interfaces/ConfigFormSyncInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic, Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -10,6 +12,8 @@
  */
 
 namespace MauticPlugin\IntegrationsBundle\Integration\Interfaces;
+
+use MauticPlugin\IntegrationsBundle\Mapping\MappedFieldInfoInterface;
 
 interface ConfigFormSyncInterface extends IntegrationInterface
 {
@@ -34,7 +38,7 @@ interface ConfigFormSyncInterface extends IntegrationInterface
      *
      * @param string $object
      *
-     * @return array
+     * @return array|MappedFieldInfoInterface[]
      */
     public function getRequiredFieldsForMapping(string $object): array;
 
@@ -43,7 +47,7 @@ interface ConfigFormSyncInterface extends IntegrationInterface
      *
      * @param string $object
      *
-     * @return array
+     * @return array|MappedFieldInfoInterface[]
      */
     public function getOptionalFieldsForMapping(string $object): array;
 

--- a/Integration/Interfaces/ConfigFormSyncInterface.php
+++ b/Integration/Interfaces/ConfigFormSyncInterface.php
@@ -34,7 +34,7 @@ interface ConfigFormSyncInterface extends IntegrationInterface
     public function getSyncMappedObjects(): array;
 
     /**
-     * Return an array of required fields in the format of [$key => $label]
+     * Return an array of required fields
      *
      * @param string $object
      *
@@ -43,13 +43,22 @@ interface ConfigFormSyncInterface extends IntegrationInterface
     public function getRequiredFieldsForMapping(string $object): array;
 
     /**
-     * Return an array of optional fields in the format of [$key => $label]
+     * Return an array of optional fields
      *
      * @param string $object
      *
      * @return array|MappedFieldInfoInterface[]
      */
     public function getOptionalFieldsForMapping(string $object): array;
+
+    /**
+     * Return an array of all fields
+     *
+     * @param string $object
+     *
+     * @return array|MappedFieldInfoInterface[]
+     */
+    public function getAllFieldsForMapping(string $object): array;
 
     /**
      * Return a custom form field name to be included in the features array specific to sync

--- a/Mapping/MappedFieldInfoInterface.php
+++ b/Mapping/MappedFieldInfoInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\IntegrationsBundle\Mapping;
+
+interface MappedFieldInfoInterface
+{
+    public function getName(): string;
+    public function getFormType() :string;
+    public function getLabel(): string;
+    public function isMandatory(): bool;
+}

--- a/Mapping/MappedFieldInfoInterface.php
+++ b/Mapping/MappedFieldInfoInterface.php
@@ -28,7 +28,7 @@ interface MappedFieldInfoInterface
     /**
      * @return bool
      */
-    public function isRequired(): bool;
+    public function showAsRequired(): bool;
 
     /**
      * @return bool

--- a/Mapping/MappedFieldInfoInterface.php
+++ b/Mapping/MappedFieldInfoInterface.php
@@ -15,8 +15,18 @@ namespace MauticPlugin\IntegrationsBundle\Mapping;
 
 interface MappedFieldInfoInterface
 {
+    /**
+     * @return string
+     */
     public function getName(): string;
-    public function getFormType() :string;
+
+    /**
+     * @return string
+     */
     public function getLabel(): string;
+
+    /**
+     * @return bool
+     */
     public function isMandatory(): bool;
 }

--- a/Mapping/MappedFieldInfoInterface.php
+++ b/Mapping/MappedFieldInfoInterface.php
@@ -33,6 +33,16 @@ interface MappedFieldInfoInterface
     /**
      * @return bool
      */
+    public function hasTooltip(): bool;
+
+    /**
+     * @return string
+     */
+    public function getTooltip(): string;
+
+    /**
+     * @return bool
+     */
     public function isBidirectionalSyncEnabled(): bool;
 
     /**

--- a/Mapping/MappedFieldInfoInterface.php
+++ b/Mapping/MappedFieldInfoInterface.php
@@ -29,4 +29,19 @@ interface MappedFieldInfoInterface
      * @return bool
      */
     public function isMandatory(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isBidirectionalSyncEnabled(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isToIntegrationSyncEnabled(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isToMauticSyncEnabled(): bool;
 }

--- a/Mapping/MappedFieldInfoInterface.php
+++ b/Mapping/MappedFieldInfoInterface.php
@@ -28,7 +28,7 @@ interface MappedFieldInfoInterface
     /**
      * @return bool
      */
-    public function isMandatory(): bool;
+    public function isRequired(): bool;
 
     /**
      * @return bool


### PR DESCRIPTION
Refactored mapped fields for config form - use object that implements an interface.

This PR depends on https://github.com/mautic-inc/plugin-magento/pull/3 and https://github.com/mautic-inc/plugin-vtiger/pull/36. It has to be merged together.

Take a look to PRs mentioned above to test this PR.