### PR TITLE
old_reason doesn not exist for the first unsubscribtion

### DIFF
--- a/EventListener/LeadSubscriber.php
+++ b/EventListener/LeadSubscriber.php
@@ -108,7 +108,7 @@ class LeadSubscriber extends CommonSubscriber
         if (isset($changes['dnc_channel_status'])) {
             $dncChanges = [];
             foreach ($changes['dnc_channel_status'] as $channel => $change) {
-                $oldValue = $change['old_reason'];
+                $oldValue = isset($change['old_reason']) ? $change['old_reason'] : '';
                 $newValue = $change['reason'];
 
                 $dncChanges['mautic_internal_dnc_'.$channel] = [$oldValue, $newValue];


### PR DESCRIPTION
Simple fix.

### Steps to replicate
1. Try to unsubscribe a contact from the administration even from a batch action or the preference center and notice the notice.