### PR TITLE
Fixes MAUT-2696 with config save issues

### DIFF
--- a/Assets/js/integrations.js
+++ b/Assets/js/integrations.js
@@ -1,6 +1,6 @@
 Mautic.integrationsConfigOnLoad = function () {
     mQuery('.integration-keyword-filter').each(function() {
-        mQuery(this).on("keydown", function (event) {
+        mQuery(this).off("keydown.integration-filter").on("keydown.integration-filter", function (event) {
             if (event.which == 13) {
                 var integration = mQuery(this).attr('data-integration');
                 var object = mQuery(this).attr('data-object');
@@ -114,7 +114,7 @@ Mautic.updateIntegrationField = function(integration, object, field, fieldOption
 
 Mautic.activateIntegrationFieldUpdateActions = function () {
     mQuery('.integration-mapped-field').each(function() {
-        mQuery(this).on("change", function (event) {
+        mQuery(this).off("change.integration-mapped-field").on("change.integration-mapped-field", function (event) {
             var integration = mQuery(this).attr('data-integration');
             var object = mQuery(this).attr('data-object');
             var field = mQuery(this).attr('data-field');
@@ -123,7 +123,7 @@ Mautic.activateIntegrationFieldUpdateActions = function () {
     });
 
     mQuery('.integration-sync-direction').each(function() {
-        mQuery(this).on("change", function (event) {
+        mQuery(this).off("change.integration-sync-direction").on("change.integration-sync-direction", function (event) {
             var integration = mQuery(this).attr('data-integration');
             var object = mQuery(this).attr('data-object');
             var field = mQuery(this).attr('data-field');

--- a/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -70,13 +70,16 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
             throw new InvalidFormOptionException('field "'.$field->getName().'" must allow at least 1 direction for sync');
         }
 
+        reset($choices);
+        $defaultChoice = key($choices);
+
         $builder->add(
             'syncDirection',
             ChoiceType::class,
             [
                 'choices'    => $choices,
                 'label'      => false,
-                'empty_data' => ObjectMappingDAO::SYNC_BIDIRECTIONALLY,
+                'empty_data' => $defaultChoice,
                 'attr'       => [
                     'class'            => 'integration-sync-direction',
                     'data-object'      => $options['object'],


### PR DESCRIPTION
This fixes two bugs. One is with one directional fields due to the `empty_data` of the sync direction defaulting to bidirectional and that not being a valid option. 

To reproduce:
1. I have the Lead and Contact objects enabled.
2. I go to the Contact Field Mapping tab
3. I map the 2 required fields: email and last name.
4. Apply the changes.
5. Search for the Salutation field
6. Map that field
7. Apply the changes
8. You get a validation error that required fields aren't mapped. The mapping you did in step 3 are cleared.

To test:
Repeat and the form should save

It also fixes a bug where event binding was happening twice due to using the same method to both callbacks in https://github.com/mautic-inc/plugin-integrations/blob/9e67e06f81e3b1fd3e50f9399a00c47dc598a02c/Views/Config/form.html.php#L12. 

To reproduce:
1. Browse to the plugin page and refresh the screen
2. Click on the Plugins menu item again
3. Open developer tools and look at the network tab
4. Open the new SF plugin config
5. Click on the Lead Fields tab
6. Filter for Salutation
7. Notice that two ajax requests are fired (the second cancelling the first)
8. Also map a field and notice two ajax requests

To test:
Repeat and there should only be one ajax request and the fields should be filtered and/or mapped