### PR TITLE
Fixing 2 bugs in the updateIntegrationObject method

### DIFF
--- a/Entity/ObjectMappingRepository.php
+++ b/Entity/ObjectMappingRepository.php
@@ -91,7 +91,7 @@ class ObjectMappingRepository  extends CommonRepository
     {
         $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $qb->update(MAUTIC_TABLE_PREFIX.'sync_object_mapping')
+        $qb->update(MAUTIC_TABLE_PREFIX.'sync_object_mapping', 'i')
             ->set('integration_object_name', ':newObjectName')
             ->set('integration_object_id', ':newObjectId')
             ->where(
@@ -107,7 +107,7 @@ class ObjectMappingRepository  extends CommonRepository
             ->setParameter('oldObjectName', $oldObjectName)
             ->setParameter('oldObjectId', $oldObjectId);
 
-        return $qb->execute()->rowCount();
+        return $qb->execute();
     }
 
     /**


### PR DESCRIPTION
1. The table alias was not set so the SQL returned an error that `i.integration` does not exist.
2. `->rowCount()` was called on int.

There is no way how to test it as it appears this method was not really called yet. I didn't end up using it in the integration I'm working on and used another approach instead so I cannot provide a code to test it with either. But the code changes are simple and make sense. Code review should suffice.