### PR TITLE
Fixes for bi-directional DNC Salesforce sync

### DIFF
--- a/Sync/Helper/MappingHelper.php
+++ b/Sync/Helper/MappingHelper.php
@@ -11,6 +11,8 @@
 
 namespace MauticPlugin\IntegrationsBundle\Sync\Helper;
 
+use Mautic\LeadBundle\Entity\Company as CompanyEntity;
+use Mautic\LeadBundle\Entity\Lead as LeadEntity;
 use Mautic\LeadBundle\Model\FieldModel;
 use MauticPlugin\IntegrationsBundle\Entity\ObjectMapping;
 use MauticPlugin\IntegrationsBundle\Entity\ObjectMappingRepository;
@@ -143,6 +145,29 @@ class MappingHelper
         $this->saveObjectMapping($objectMapping);
 
         return new ObjectDAO($internalObjectName, $objectId);
+    }
+
+    /**
+     * Returns corresponding Mautic entity for the given Mautic object
+     *
+     * @param string $internalObject
+     * @return string
+     */
+    public function getMauticEntity(string $internalObject): string
+    {
+        switch ($internalObject) {
+            case MauticSyncDataExchange::OBJECT_CONTACT:
+                $entity = LeadEntity::class;
+                break;
+            case MauticSyncDataExchange::OBJECT_COMPANY:
+                $entity = CompanyEntity::class;
+                break;
+            default:
+                $entity = $internalObject;
+                break;
+        }
+
+        return $entity;
     }
 
     /**

--- a/Sync/Helper/MappingHelper.php
+++ b/Sync/Helper/MappingHelper.php
@@ -148,7 +148,7 @@ class MappingHelper
     }
 
     /**
-     * Returns corresponding Mautic entity for the given Mautic object
+     * Returns corresponding Mautic entity class name for the given Mautic object
      *
      * @param string $internalObject
      * @return string

--- a/Sync/Helper/MappingHelper.php
+++ b/Sync/Helper/MappingHelper.php
@@ -152,8 +152,9 @@ class MappingHelper
      *
      * @param string $internalObject
      * @return string
+     * @throws ObjectNotSupportedException
      */
-    public function getMauticEntity(string $internalObject): string
+    public function getMauticEntityClassName(string $internalObject): string
     {
         switch ($internalObject) {
             case MauticSyncDataExchange::OBJECT_CONTACT:
@@ -163,8 +164,7 @@ class MappingHelper
                 $entity = CompanyEntity::class;
                 break;
             default:
-                $entity = $internalObject;
-                break;
+                throw new ObjectNotSupportedException(MauticSyncDataExchange::NAME, $internalObject);
         }
 
         return $entity;

--- a/Sync/SyncDataExchange/MauticSyncDataExchange.php
+++ b/Sync/SyncDataExchange/MauticSyncDataExchange.php
@@ -137,7 +137,7 @@ class MauticSyncDataExchange implements SyncDataExchangeInterface
 
         $fieldChanges = $this->fieldChangeRepository->findChangesForObject(
             $mappingManualDAO->getIntegration(),
-            $this->mappingHelper->getMauticEntity($internalObjectName),
+            $this->mappingHelper->getMauticEntityClassName($internalObjectName),
             $internalObjectDAO->getObjectId()
         );
 

--- a/Sync/SyncDataExchange/MauticSyncDataExchange.php
+++ b/Sync/SyncDataExchange/MauticSyncDataExchange.php
@@ -137,7 +137,7 @@ class MauticSyncDataExchange implements SyncDataExchangeInterface
 
         $fieldChanges = $this->fieldChangeRepository->findChangesForObject(
             $mappingManualDAO->getIntegration(),
-            $internalObjectName,
+            $this->mappingHelper->getMauticEntity($internalObjectName),
             $internalObjectDAO->getObjectId()
         );
 

--- a/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
+++ b/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
@@ -287,8 +287,18 @@ class ObjectChangeGenerator
             $internalField->getName(),
             $internalField->getValue()
         );
-        $internalInformationChangeRequest->setPossibleChangeDateTime($this->internalObject->getChangeDateTime());
-        $internalInformationChangeRequest->setCertainChangeDateTime($internalField->getChangeDateTime());
+
+        $possibleChangeDateTime = $this->internalObject->getChangeDateTime();
+        $certainChangeDateTime = $internalField->getChangeDateTime();
+
+        // If we know certain change datetime and it's newer than possible change datetime
+        // then we have to update possible change datetime otherwise comparision doesn't work correctly
+        if ($certainChangeDateTime && ($certainChangeDateTime > $possibleChangeDateTime)) {
+            $possibleChangeDateTime = $certainChangeDateTime;
+        }
+
+        $internalInformationChangeRequest->setPossibleChangeDateTime($possibleChangeDateTime);
+        $internalInformationChangeRequest->setCertainChangeDateTime($certainChangeDateTime);
 
         // There is a conflict so let the judge determine which value comes out on top
         foreach ($this->judgementModes as $judgeMode) {


### PR DESCRIPTION
JIRA: https://backlog.acquia.com/browse/MAUT-138

This PR is needed to make DNC sync properly work in Salesforce.

Steps to test this PR:
1. Enable new Salesforce plugin on your Mautic instance.
Authorize it.
Make sure mappings for "Do No Contact" and the required fields are set.
2. Synchronize contacts
```
php app/console mautic:integrations:sync Salesforce2
```
3. Open any Salesforce contact in Mautic. Set "Do Not Contact" status for it.
4. Open the same lead in the Salesforce. Check (enable) "Email Opt Out" value for it. Save it.
5. Go to the Mautic contact from step 3.
Remove "Do Not Contact" status for it.
6. 
```
php app/console mautic:integrations:sync Salesforce2
```
**Expected Result**:
Both Mautic contact and Salesforce lead must **NOT** be marked as "Do Not Contact".

**Actual Result**:
Mautic contact is marked as "Do Not Contact".

So, this PR fixes it and both entities should have correct DNC status.