### PR TITLE
Fix failing tests

### DIFF
--- a/Tests/Command/SyncCommandTest.php
+++ b/Tests/Command/SyncCommandTest.php
@@ -26,6 +26,7 @@ use MauticPlugin\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange
  * MAUTIC_INTEGRATION_SYNC_IN_PROGRESS which breaks other tests.
  * 
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class SyncCommandTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
These tests do not need global state so do not pass it. This also prevents test failures due to dirty state from previous tests.