### PR TITLE
Throw exception when debug is ON

### DIFF
--- a/Command/SyncCommand.php
+++ b/Command/SyncCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\IntegrationsBundle\Command;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use MauticPlugin\IntegrationsBundle\Exception\InvalidValueException;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Sync\InputOptionsDAO;
 use MauticPlugin\IntegrationsBundle\Sync\SyncService\SyncServiceInterface;
@@ -32,13 +33,22 @@ class SyncCommand extends ContainerAwareCommand
     private $syncService;
 
     /**
-     * @param SyncServiceInterface $syncService
+     * @var CoreParametersHelper
      */
-    public function __construct(SyncServiceInterface $syncService)
-    {
+    private $coreParametersHelper;
+
+    /**
+     * @param SyncServiceInterface $syncService
+     * @param CoreParametersHelper $coreParametersHelper
+     */
+    public function __construct(
+        SyncServiceInterface $syncService,
+        CoreParametersHelper $coreParametersHelper
+    ) {
         parent::__construct();
 
-        $this->syncService = $syncService;
+        $this->syncService          = $syncService;
+        $this->coreParametersHelper = $coreParametersHelper;
     }
 
     /**
@@ -120,7 +130,7 @@ class SyncCommand extends ContainerAwareCommand
 
             $this->syncService->processIntegrationSync($inputOptions);
         } catch (\Throwable $e) {
-            if ('dev' === $input->getOption('env') || (defined('MAUTIC_ENV') && MAUTIC_ENV === 'dev')) {
+            if ('dev' === $input->getOption('env') || (defined('MAUTIC_ENV') && MAUTIC_ENV === 'dev') || $this->coreParametersHelper->getParameter('debug', false)) {
                 throw $e;
             }
 

--- a/Config/config.php
+++ b/Config/config.php
@@ -52,6 +52,7 @@ return [
                 'class'     => \MauticPlugin\IntegrationsBundle\Command\SyncCommand::class,
                 'arguments' => [
                     'mautic.integrations.sync.service',
+                    'mautic.helper.core_parameters',
                 ],
                 'tag' => 'console.command',
             ],

--- a/Tests/Unit/Command/SyncCommandTest.php
+++ b/Tests/Unit/Command/SyncCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\IntegrationsBundle\Tests\Unit\Command;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use MauticPlugin\IntegrationsBundle\Command\SyncCommand;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Sync\InputOptionsDAO;
 use MauticPlugin\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
@@ -38,6 +39,11 @@ class SyncCommandTest extends \PHPUnit_Framework_TestCase
     private $syncService;
 
     /**
+     * @var CoreParametersHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paramsHelper;
+
+    /**
      * @var CommandTester
      */
     private $commandTester;
@@ -46,10 +52,11 @@ class SyncCommandTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->syncService = $this->createMock(SyncServiceInterface::class);
-        $application       = new Application();
+        $this->syncService  = $this->createMock(SyncServiceInterface::class);
+        $this->paramsHelper = $this->createMock(CoreParametersHelper::class);
+        $application        = new Application();
 
-        $application->add(new SyncCommand($this->syncService));
+        $application->add(new SyncCommand($this->syncService, $this->paramsHelper));
 
         // env is global option. Must be defined.
         $application->getDefinition()->addOption(


### PR DESCRIPTION
We encountered a problem that the sync command returns either just this:
```
Command `mautic:integrations:sync` exited with status code 1
```
Or this:
```
Queued from job ID# 2835Command: exec php /var/www/hosted/sfv2-beta/public_html/../console mautic:integrations:sync -e prod Salesforce2 --start-datetime="2019-10-08 07:05:36" --end-datetime="2019-10-08 07:10:44"
Hostname: mautic-workers-beta-sssp5
{{ [ERROR] DateTime::__construct() expects parameter 1 to be string, null given }}
Result code: 1
job complete
```
No stack trace. I cannot confirm this will help but I hope it will. The instance is in debug mode (`'debug' => true,` in local.php) but the command is run as production. So I added another OR statement that check if the debug param is not false.