### PR TITLE
MAUT-2834 Do not put "Unkown" value to empty required fields

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -267,9 +267,7 @@ return [
             ],
             'mautic.integrations.sync.sync_process.value_helper' => [
                 'class'     => \MauticPlugin\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper::class,
-                'arguments' => [
-                    'translator',
-                ],
+                'arguments' => [],
             ],
             'mautic.integrations.sync.data_exchange.mautic.field_builder' => [
                 'class'     => \MauticPlugin\IntegrationsBundle\Sync\SyncDataExchange\Internal\ReportBuilder\FieldBuilder::class,

--- a/Sync/SyncProcess/Direction/Helper/ValueHelper.php
+++ b/Sync/SyncProcess/Direction/Helper/ValueHelper.php
@@ -17,15 +17,9 @@ use MauticPlugin\IntegrationsBundle\Exception\InvalidValueException;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class ValueHelper
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
     /**
      * @var NormalizedValueDAO
      */
@@ -40,14 +34,6 @@ class ValueHelper
      * @var string
      */
     private $syncDirection;
-
-    /**
-     * @param TranslatorInterface $translator
-     */
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
 
     /**
      * @param NormalizedValueDAO $normalizedValueDAO

--- a/Sync/SyncProcess/Direction/Helper/ValueHelper.php
+++ b/Sync/SyncProcess/Direction/Helper/ValueHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\IntegrationsBundle\Sync\SyncProcess\Direction\Helper;
 
+use MauticPlugin\IntegrationsBundle\Exception\InvalidValueException;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
@@ -54,6 +55,8 @@ class ValueHelper
      * @param string             $syncDirection
      *
      * @return NormalizedValueDAO
+     *
+     * @throws InvalidValueException
      */
     public function getValueForIntegration(NormalizedValueDAO $normalizedValueDAO, string $fieldState, string $syncDirection): NormalizedValueDAO
     {
@@ -72,6 +75,8 @@ class ValueHelper
      * @param string             $syncDirection
      *
      * @return NormalizedValueDAO
+     *
+     * @throws InvalidValueException
      */
     public function getValueForMautic(NormalizedValueDAO $normalizedValueDAO, string $fieldState, string $syncDirection): NormalizedValueDAO
     {
@@ -88,6 +93,8 @@ class ValueHelper
      * @param string $directionToIgnore
      *
      * @return float|int|mixed|string
+     *
+     * @throws InvalidValueException
      */
     private function getValue(string $directionToIgnore)
     {
@@ -121,7 +128,7 @@ class ValueHelper
             case NormalizedValueDAO::FLOAT_TYPE:
                 return 1.0;
             default:
-                return $this->translator->trans('mautic.core.unknown');
+                throw new InvalidValueException("Required field can't be empty");
         }
     }
 }

--- a/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
+++ b/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\IntegrationsBundle\Sync\SyncProcess\Direction\Integration;
 
+use MauticPlugin\IntegrationsBundle\Exception\InvalidValueException;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\FieldMappingDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
@@ -151,11 +152,15 @@ class ObjectChangeGenerator
             return;
         }
 
-        $newValue = $this->valueHelper->getValueForIntegration(
-            $internalInformationChangeRequest->getNewValue(),
-            $fieldState,
-            $fieldMappingDAO->getSyncDirection()
-        );
+        try {
+            $newValue = $this->valueHelper->getValueForIntegration(
+                $internalInformationChangeRequest->getNewValue(),
+                $fieldState,
+                $fieldMappingDAO->getSyncDirection()
+            );
+        } catch (InvalidValueException $e) {
+            return; // Field has to be skipped
+        }
 
         // Note: bidirectional conflicts were handled by Internal\ObjectChangeGenerator
         $this->objectChange->addField(

--- a/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
+++ b/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\IntegrationsBundle\Sync\SyncProcess\Direction\Internal;
 
+use MauticPlugin\IntegrationsBundle\Exception\InvalidValueException;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\FieldMappingDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
@@ -194,11 +195,15 @@ class ObjectChangeGenerator
             return;
         }
 
-        $newValue = $this->valueHelper->getValueForMautic(
-            $integrationInformationChangeRequest->getNewValue(),
-            $internalFieldState,
-            $fieldMappingDAO->getSyncDirection()
-        );
+        try {
+            $newValue = $this->valueHelper->getValueForMautic(
+                $integrationInformationChangeRequest->getNewValue(),
+                $internalFieldState,
+                $fieldMappingDAO->getSyncDirection()
+            );
+        } catch (InvalidValueException $e) {
+            return; // Field has to be skipped
+        }
 
         // Add the value to the field based on the field state
         $this->objectChange->addField(

--- a/Tests/Unit/Sync/SyncProcess/Direction/Helper/ValueHelperTest.php
+++ b/Tests/Unit/Sync/SyncProcess/Direction/Helper/ValueHelperTest.php
@@ -18,26 +18,9 @@ use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
 use MauticPlugin\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class ValueHelperTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    protected function setUp(): void
-    {
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->translator->method('trans')
-            ->willReturnCallback(
-                function ($key) {
-                    return $key;
-                }
-            );
-    }
-
     public function testExceptionForMissingRequiredIntegrationValue(): void
     {
         $this->expectException(InvalidValueException::class);
@@ -133,6 +116,6 @@ class ValueHelperTest extends \PHPUnit_Framework_TestCase
      */
     private function getValueHelper()
     {
-        return new ValueHelper($this->translator);
+        return new ValueHelper();
     }
 }

--- a/Tests/Unit/Sync/SyncProcess/Direction/Helper/ValueHelperTest.php
+++ b/Tests/Unit/Sync/SyncProcess/Direction/Helper/ValueHelperTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\IntegrationsBundle\Tests\Unit\Sync\SyncProcess\Direction\Helper;
 
+use MauticPlugin\IntegrationsBundle\Exception\InvalidValueException;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO;
 use MauticPlugin\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
@@ -37,23 +38,20 @@ class ValueHelperTest extends \PHPUnit_Framework_TestCase
             );
     }
 
-    public function testUnkonwnReturnedForMissingRequiredIntegrationValue(): void
+    public function testExceptionForMissingRequiredIntegrationValue(): void
     {
+        $this->expectException(InvalidValueException::class);
+
         $normalizedValueDAO = new NormalizedValueDAO(NormalizedValueDAO::STRING_TYPE, '');
 
-        $newValue = $this->getValueHelper()->getValueForIntegration(
+        $this->getValueHelper()->getValueForIntegration(
             $normalizedValueDAO,
             FieldDAO::FIELD_REQUIRED,
             ObjectMappingDAO::SYNC_TO_INTEGRATION
         );
-
-        $this->assertEquals(
-            'mautic.core.unknown',
-            $newValue->getNormalizedValue()
-        );
     }
 
-    public function testUnkonwnIsNotReturnedForMissingNonRequiredIntegrationValue(): void
+    public function testNoExceptionForMissingNonRequiredIntegrationValue(): void
     {
         $normalizedValueDAO = new NormalizedValueDAO(NormalizedValueDAO::STRING_TYPE, '');
 
@@ -69,7 +67,7 @@ class ValueHelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testUnkonwnIsNotReturnedForMissingOppositeSyncIntegrationValue(): void
+    public function testNoExceptionForMissingOppositeSyncIntegrationValue(): void
     {
         $normalizedValueDAO = new NormalizedValueDAO(NormalizedValueDAO::STRING_TYPE, '');
 
@@ -85,23 +83,20 @@ class ValueHelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testUnkonwnReturnedForMissingRequiredMauticValue(): void
+    public function testExceptionForMissingRequiredMauticValue(): void
     {
+        $this->expectException(InvalidValueException::class);
+
         $normalizedValueDAO = new NormalizedValueDAO(NormalizedValueDAO::STRING_TYPE, '');
 
-        $newValue = $this->getValueHelper()->getValueForMautic(
+        $this->getValueHelper()->getValueForMautic(
             $normalizedValueDAO,
             FieldDAO::FIELD_REQUIRED,
             ObjectMappingDAO::SYNC_TO_MAUTIC
         );
-
-        $this->assertEquals(
-            'mautic.core.unknown',
-            $newValue->getNormalizedValue()
-        );
     }
 
-    public function testUnkonwnIsNotReturnedForMissingNonRequiredInternalValue(): void
+    public function testNoExceptionForMissingNonRequiredInternalValue(): void
     {
         $normalizedValueDAO = new NormalizedValueDAO(NormalizedValueDAO::STRING_TYPE, '');
 
@@ -117,7 +112,7 @@ class ValueHelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testUnkonwnIsNotReturnedForMissingOppositeSyncInternalnValue(): void
+    public function testNoExceptionForMissingOppositeSyncInternalnValue(): void
     {
         $normalizedValueDAO = new NormalizedValueDAO(NormalizedValueDAO::STRING_TYPE, '');
 


### PR DESCRIPTION
IntegrationsBundle adds "Unknown" string to all required fields that are empty. This way all contacts/leads will be created in SF even if they are invalid. It should not push invalid objects.
We'll have to check it did not break Salesforce v2 plugin, Magento and Vtiger. 

https://backlog.acquia.com/browse/MAUT-2834

#### Steps to test this PR:
1. Load up this PR
2. Prepare a contact with empty field, that is required in SF
3. Allow contact sync in SF plugin, run SF sync
4. The invalid contact shouldn't be created in SF

EDIT: (Lukas)
**2. I used as empty required field for SF `Last Name` field in new contact**