### PR TITLE
Prevent exception when db_table_prefix is not defined in the config

### DIFF
--- a/Bundle/AbstractPluginBundle.php
+++ b/Bundle/AbstractPluginBundle.php
@@ -36,7 +36,9 @@ abstract class AbstractPluginBundle extends PluginBundleBase
     public static function onPluginUpdate(Plugin $plugin, MauticFactory $factory, $metadata = null, ?Schema $installedSchema = null): void
     {
         $entityManager = $factory->getEntityManager();
-        $tablePrefix   = $factory->getParameter('mautic.db_table_prefix');
+
+        /** @var string $tablePrefix */
+        $tablePrefix = $factory->getParameter('mautic.db_table_prefix', '');
 
         $migrationEngine = new Engine(
             $entityManager,

--- a/Bundle/AbstractPluginBundle.php
+++ b/Bundle/AbstractPluginBundle.php
@@ -36,9 +36,7 @@ abstract class AbstractPluginBundle extends PluginBundleBase
     public static function onPluginUpdate(Plugin $plugin, MauticFactory $factory, $metadata = null, ?Schema $installedSchema = null): void
     {
         $entityManager = $factory->getEntityManager();
-
-        /** @var string $tablePrefix */
-        $tablePrefix = (string) $factory->getParameter('mautic.db_table_prefix');
+        $tablePrefix   = (string) $factory->getParameter('mautic.db_table_prefix');
 
         $migrationEngine = new Engine(
             $entityManager,

--- a/Bundle/AbstractPluginBundle.php
+++ b/Bundle/AbstractPluginBundle.php
@@ -38,7 +38,7 @@ abstract class AbstractPluginBundle extends PluginBundleBase
         $entityManager = $factory->getEntityManager();
 
         /** @var string $tablePrefix */
-        $tablePrefix = $factory->getParameter('mautic.db_table_prefix', '');
+        $tablePrefix = (string) $factory->getParameter('mautic.db_table_prefix');
 
         $migrationEngine = new Engine(
             $entityManager,


### PR DESCRIPTION
An exception is thrown when running the `mautic:plugins:install` command when `db_table_prefix` is not defined in Mautic's config file and thus the core parameters helper returns `null` by default. 

```
Type error: Argument 2 passed to MauticPlugin\IntegrationsBundle\Migration\Engine::__construct() must be of the type string, null given, called in plugins/IntegrationsBundle/Bundle/AbstractPluginBundle.php on line 43 
```

This simply typecasts as an empty string to prevent that exception. 

Testing is complicated as it requires having a schema prior to the latest staging of IntegrationsBundle and a setup that does not use a prefix. 

It's safe enough to code review. 