### PR TITLE
Remove objectId type

### DIFF
--- a/Entity/FieldChangeRepository.php
+++ b/Entity/FieldChangeRepository.php
@@ -48,11 +48,11 @@ class FieldChangeRepository extends CommonRepository
     /**
      * Takes an object id & type and deletes all entities that match.
      *
-     * @param int         $objectId
+     * @param int|string         $objectId
      * @param string      $objectType
      * @param string|null $integration
      */
-    public function deleteEntitiesForObject(int $objectId, string $objectType, ?string $integration = null): void
+    public function deleteEntitiesForObject($objectId, string $objectType, ?string $integration = null): void
     {
         $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
 

--- a/Sync/DAO/Sync/ObjectIdsDAO.php
+++ b/Sync/DAO/Sync/ObjectIdsDAO.php
@@ -60,9 +60,9 @@ class ObjectIdsDAO
 
     /**
      * @param string $objectType
-     * @param string $id
+     * @param int|string $id
      */
-    public function addObjectId(string $objectType, string $id): void
+    public function addObjectId(string $objectType, $id): void
     {
         if (!isset($this->objects[$objectType])) {
             $this->objects[$objectType] = [];


### PR DESCRIPTION
 If we are using campaign action push contacts to integration, addObjectId expect string as second parameter. Do we need it? 
 ```
    public function pushContacts(PendingEvent $event)
    {
        $contactIds = $event->getContactIds();

        $mauticObjectIds = new ObjectIdsDAO();
        foreach ($contactIds as $contactId) {
            $mauticObjectIds->addObjectId('lead', $contactId);
        }
    }
```
Throw error

>  Type error: Argument 2 passed to MauticPlugin\IntegrationsBundle\Sync\DAO\Sync\ObjectIdsDAO::addObjectId() must be
>   of the type string or null, integer given, called in C:\wamp3-1-4\www\Automation_dev\plugins\MauticYellowboxCrmBund
>   le\EventListener\PushDataCampaignSubscriber.php on line 81

Second change fixed this error   also during push contact to integration

> Type error: Argument 1 passed to MauticPlugin\IntegrationsBundle\Entity\FieldChangeRepository::deleteEntitiesForObj
>   ect() must be of the type integer, string given, called in C:\wamp3-1-4\www\Automation_dev\plugins\IntegrationsBund
>   le\Sync\SyncDataExchange\MauticSyncDataExchange.php on line 159