### PR TITLE
Create special handling of the owner_id pseudo field

### DIFF
--- a/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilder.php
+++ b/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilder.php
@@ -128,7 +128,7 @@ class FieldBuilder
 
     /**
      * @param string $field
-     * @param int $ownerId
+     * @param int    $ownerId
      *
      * @return ReportFieldDAO
      */

--- a/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilder.php
+++ b/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilder.php
@@ -93,6 +93,11 @@ class FieldBuilder
             return $this->addContactIdField($field);
         }
 
+        // Special handling of the owner ID field
+        if ('owner_id' === $field) {
+            return $this->createOwnerIdReportFieldDAO($field, (int) $mauticObject['owner_id']);
+        }
+
         // Special handling of DNC fields
         if (0 === strpos($field, 'mautic_internal_dnc_')) {
             return $this->addDoNotContactField($field);
@@ -119,6 +124,23 @@ class FieldBuilder
         );
 
         return new ReportFieldDAO($field, $normalizedValue);
+    }
+
+    /**
+     * @param string $field
+     * @param int $ownerId
+     *
+     * @return ReportFieldDAO
+     */
+    private function createOwnerIdReportFieldDAO(string $field, int $ownerId)
+    {
+        return new ReportFieldDAO(
+            $field,
+            new NormalizedValueDAO(
+                NormalizedValueDAO::INT_TYPE,
+                $ownerId
+            )
+        );
     }
 
     /**

--- a/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilderTest.php
+++ b/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilderTest.php
@@ -56,6 +56,19 @@ class FieldBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $field->getValue()->getNormalizedValue());
     }
 
+    public function testOwnerIdFieldIsAdded(): void
+    {
+        $field = $this->getFieldBuilder()->buildObjectField(
+            'owner_id',
+            ['id' => 1, 'owner_id' => 123],
+            new ObjectDAO('Test'),
+            'Test'
+        );
+
+        $this->assertEquals('owner_id', $field->getName());
+        $this->assertEquals(123, $field->getValue()->getNormalizedValue());
+    }
+
     public function testDoNotContactFieldIsAdded(): void
     {
         $this->contactObjectHelper->expects($this->once())


### PR DESCRIPTION
I was getting
```
CAMPAIGN: The owner_id field is not mapped for the lead object.
```
error when creating a task on a SF lead that did not exist in SF yet and so it should be created right before the task. It did not throw this error when creating a task for an existing SF lead.

This change was probably needed to be done together with https://github.com/mautic-inc/plugin-integrations/pull/54 when the `owner_id` pseudo field was created. But somehow the sync works without it except some special case.

When you look at that modified class it's evident that all other pseudo fields are being handled on this same place too.

### Steps to reproduce
1. Checkout https://github.com/mautic-inc/plugin-salesforce/pull/67
2. Create a new contact
3. Create a new segment
4. Add the contact (2) to the segment (3)
5. Create a campaign to create a SF task. Base it on the segment (3)
6. Run `app/console mautic:campaigns:update`
7. Run `app/console mautic:campaigns:trigger -e dev -vvv` and see the error.