### PR TITLE
MAUT-2903 Fix push of changed points

### DIFF
--- a/EventListener/LeadSubscriber.php
+++ b/EventListener/LeadSubscriber.php
@@ -103,6 +103,11 @@ class LeadSubscriber extends CommonSubscriber
             $changes['fields']['owner_id'] = $changes['owner'];
         }
 
+        if (!empty($changes['points'])) {
+            // Add ability to update points custom field in target
+            $changes['fields']['points'] = $changes['points'];
+        }
+
         if (isset($changes['fields'])) {
             $this->recordFieldChanges($changes['fields'], $lead->getId(), Lead::class);
         }


### PR DESCRIPTION
Point changes push was not possible because of missing record in mautic_sync_object_field_change_report.
