### PR TITLE
Fix bug in TokenPersistence::restoreToken

### DIFF
--- a/Auth/Support/Oauth2/Token/TokenPersistence.php
+++ b/Auth/Support/Oauth2/Token/TokenPersistence.php
@@ -52,8 +52,8 @@ class TokenPersistence implements TokenPersistenceInterface
         $apiKeys['expires_at'] = $apiKeys['expires_at'] ?? null;
 
         return new IntegrationToken(
-            $apiKeys['access_token'] ?? null,
-            $apiKeys['refresh_token'] ?? null,
+            empty($apiKeys['access_token']) ? null : $apiKeys['access_token'],
+            empty($apiKeys['refresh_token']) ? null : $apiKeys['refresh_token'],
             $apiKeys['expires_at'] ? $apiKeys['expires_at'] - time() : -1
         );
     }

--- a/Auth/Support/Oauth2/Token/TokenPersistence.php
+++ b/Auth/Support/Oauth2/Token/TokenPersistence.php
@@ -52,7 +52,7 @@ class TokenPersistence implements TokenPersistenceInterface
         $apiKeys['expires_at'] = $apiKeys['expires_at'] ?? null;
 
         return new IntegrationToken(
-            empty($apiKeys['access_token']) ? null : $apiKeys['access_token'],
+            empty($apiKeys['access_token'] ) ? null : $apiKeys['access_token'],
             empty($apiKeys['refresh_token']) ? null : $apiKeys['refresh_token'],
             $apiKeys['expires_at'] ? $apiKeys['expires_at'] - time() : -1
         );

--- a/Auth/Support/Oauth2/Token/TokenPersistence.php
+++ b/Auth/Support/Oauth2/Token/TokenPersistence.php
@@ -52,7 +52,7 @@ class TokenPersistence implements TokenPersistenceInterface
         $apiKeys['expires_at'] = $apiKeys['expires_at'] ?? null;
 
         return new IntegrationToken(
-            empty($apiKeys['access_token'] ) ? null : $apiKeys['access_token'],
+            empty($apiKeys['access_token']) ? null : $apiKeys['access_token'],
             empty($apiKeys['refresh_token']) ? null : $apiKeys['refresh_token'],
             $apiKeys['expires_at'] ? $apiKeys['expires_at'] - time() : -1
         );


### PR DESCRIPTION
https://backlog.acquia.com/browse/MAUT-2915

If $apiKeys['access_token'] equals false, it will call IntegrationToken's constructor using "false" value.
This will cause exception.
We have to always pass null or the actual value to the constructor of IntegrationToken class.

Steps to reproduce:
I don't know how exactly this happened, but `$apiKeys['access_token']` was set to false.
If we call IntegrationToken's constructor and pass false value to it it will throw exception.

How to test this:
Just make sure you are able to authorize your SalesforcePlugin (v2).
