### PR TITLE
Add possibility to have only isPublished interface without Auth

### DIFF
--- a/Controller/ConfigController.php
+++ b/Controller/ConfigController.php
@@ -215,7 +215,9 @@ class ConfigController extends AbstractFormController
                 $formHelper->containsErrors($form['featureSettings']['sync']['integration'])
             );
 
-        $hasAuthErrors = $integrationObject instanceof ConfigFormAuthInterface && $formHelper->containsErrors($form['apiKeys']);
+        $useAuth = $integrationObject instanceof ConfigFormAuthInterface;
+
+        $hasAuthErrors = $useAuth && $formHelper->containsErrors($form['apiKeys']);
 
         $useSyncFeatures = $integrationObject instanceof ConfigFormSyncInterface;
 
@@ -235,6 +237,7 @@ class ConfigController extends AbstractFormController
                     'activeTab'           => $this->request->get('activeTab'),
                     'showFeaturesTab'     => $showFeaturesTab,
                     'hasFeatureErrors'    => $hasFeatureErrors,
+                    'useAuth'             => $useAuth,
                     'hasAuthErrors'       => $hasAuthErrors,
                     'useSyncFeatures'     => $useSyncFeatures,
                     'useFeatureSettings'  => $useFeatureSettings,

--- a/Views/Config/form.html.php
+++ b/Views/Config/form.html.php
@@ -62,6 +62,8 @@ $activeTab = $activeTab ?: 'details-container';
     <!-- Enabled\Auth -->
     <div class="tab-pane fade <?php if ('details-container' == $activeTab): echo 'in active'; endif; ?> bdr-w-0" id="details-container">
         <?php echo $view['form']->row($form['isPublished']); ?>
+
+        <?php if ($useAuth): ?>
         <hr />
         <?php echo $view['form']->row($form['apiKeys']); ?>
         <?php if ($useAuthorizationUrl): ?>
@@ -87,6 +89,7 @@ $activeTab = $activeTab ?: 'details-container';
                 </button>
             </div>
         </div>
+        <?php endif; ?>
         <?php endif; ?>
     </div>
     <!-- Enabled\Auth -->


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

#### Description:
Add possibility to have only isPublished interface without Auth form.

So ConfigSupport.php inside plugin need only to implements ConfigFormInterface to have Enable button.

![Screenshot_2020-03-23 Manage Plugins Webmecanik Automation](https://user-images.githubusercontent.com/27768270/77325307-5fac6e00-6d18-11ea-8a78-2dbb45ff71a5.png)
