### PR TITLE
Fix delete contact/company If plugins is not initialized

### DIFF
--- a/EventListener/LeadSubscriber.php
+++ b/EventListener/LeadSubscriber.php
@@ -123,6 +123,11 @@ class LeadSubscriber extends CommonSubscriber
      */
     public function onLeadPostDelete(Events\LeadEvent $event): void
     {
+        if (!$this->syncIntegrationsHelper->hasObjectSyncEnabled(MauticSyncDataExchange::OBJECT_CONTACT)) {
+            // Only track if an integration is syncing with contacts
+            return;
+        }
+
         $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getLead()->deletedId, Lead::class);
     }
 
@@ -159,6 +164,10 @@ class LeadSubscriber extends CommonSubscriber
      */
     public function onCompanyPostDelete(Events\CompanyEvent $event): void
     {
+        if (!$this->syncIntegrationsHelper->hasObjectSyncEnabled(MauticSyncDataExchange::OBJECT_COMPANY)) {
+            // Only track if an integration is syncing with companies
+            return;
+        }
         $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getCompany()->deletedId, Company::class);
     }
 


### PR DESCRIPTION
This PR prevent if plugin is copy to plugins directory, not init by clear cache/plugins reload.

### How to reproduce
1, Copy plugin to plugins directory
2. Try delete contact
3, See error

### How to test
1, Repeat all steps
2, Error shouldn't trigger after delete contact
